### PR TITLE
feat: 补全Card英文文档react渲染，修改iconfont错误代码实例

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -242,10 +242,13 @@ After rendering, `View` loses all editing capabilities and collaboration capabil
 
 ```ts
 const engine = new Engine(container, {
-	iconFonts: {
-		url: '//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff2?t=1638071536645',
-		format: 'woff2',
-	},
+	iconFonts: [
+		{
+			url: '//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff2?t=1638071536645',
+			format: 'woff2',
+			// ...
+		},
+	],
 	// or
 	iconFonts:
 		"url('//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff2?t=1638071536645') format('woff2'), url('//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff?t=1638071536645') format('woff'), url('//at.alicdn.com/t/font_1456030_lnqmc6a6ca.ttf?t=1638071536645') format('truetype')",

--- a/docs/config/index.zh-CN.md
+++ b/docs/config/index.zh-CN.md
@@ -248,10 +248,13 @@ engine.setScrollNode(滚动条节点);
 
 ```ts
 const engine = new Engine(渲染节点, {
-	iconFonts: {
-		url: '//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff2?t=1638071536645',
-		format: 'woff2',
-	},
+	iconFonts: [
+		{
+			url: '//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff2?t=1638071536645',
+			format: 'woff2',
+			// ...
+		},
+	],
 	// or
 	iconFonts:
 		"url('//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff2?t=1638071536645') format('woff2'), url('//at.alicdn.com/t/font_1456030_lnqmc6a6ca.woff?t=1638071536645') format('woff'), url('//at.alicdn.com/t/font_1456030_lnqmc6a6ca.ttf?t=1638071536645') format('truetype')",

--- a/docs/plugin/tutorials-card.zh-CN.md
+++ b/docs/plugin/tutorials-card.zh-CN.md
@@ -252,7 +252,7 @@ export default class extends Plugin<Options> {
 	}
 	// 快捷键
 	hotkey() {
-		return this.options.hotkey || 'mod+shift+0';
+		return this.options.hotkey || 'mod+shift+f';
 	}
 	// 粘贴的时候添加需要的 schema
 	pasteSchema = (schema: SchemaInterface) => {
@@ -362,7 +362,7 @@ const EngineDemo = () => {
 export default EngineDemo;
 ```
 
-使用 `test/index.ts` 中定义的快捷键 `mod+shift+0` 就能在编辑器中插入刚才定义的卡片组件了
+使用 `test/index.ts` 中定义的快捷键 `mod+shift+f` 就能在编辑器中插入刚才定义的卡片组件了
 
 ### Vue2 渲染
 


### PR DESCRIPTION
## am-editor 文档问题
### 改动点一
内容：修改 iconfont 配置文档实例代码错误
范围：中文和英文文档，不涉及功能改动

### 改动点二
内容：修改 react Test 组件的 hotkey
范围：中文和英文文档，不涉及功能改动
改动原因：代码中实际 hotkey 为 `mod+shift+f`,文档中为 `mod+shift+0`, 由于文档影响导致 `mod+shift+0` 不能生效，使用者需要自己找原因对开发者不友好

### 改动点三
内容：补齐 Card 组件 英文文档代码内容
范围：英文文档，不涉及功能改动
