### PR TITLE
fix: 给高亮块添加 markdown 快捷指令

### DIFF
--- a/docs/plugin/plugin-lightblock.md
+++ b/docs/plugin/plugin-lightblock.md
@@ -23,3 +23,10 @@ new Engine(...,{ plugins:[lightblock] })
 // use command to execute the plugin
 engine.command.execute('lightblock');
 ```
+
+## Markdown
+
+```ts
+// use markdown syntax
+::: tip
+```

--- a/docs/plugin/plugin-lightblock.zh-CN.md
+++ b/docs/plugin/plugin-lightblock.zh-CN.md
@@ -23,3 +23,10 @@ new Engine(...,{ plugins:[lightblock] })
 //使用 command 执行插件
 engine.command.execute('lightblock');
 ```
+
+## markdown
+
+```ts
+// 支持markdown快捷语法
+::: tip
+```

--- a/plugins/lightblock/package-lock.json
+++ b/plugins/lightblock/package-lock.json
@@ -1,0 +1,57 @@
+{
+	"name": "@aomao/plugin-lightblock",
+	"version": "1.0.2",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.18.9",
+			"resolved": "http://bnpm.byted.org/@babel/runtime/-/runtime-7.18.9.tgz",
+			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@types/linkify-it": {
+			"version": "3.0.2",
+			"resolved": "http://bnpm.byted.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+			"dev": true
+		},
+		"@types/markdown-it": {
+			"version": "12.2.3",
+			"resolved": "http://bnpm.byted.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+			"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+			"dev": true,
+			"requires": {
+				"@types/linkify-it": "*",
+				"@types/mdurl": "*"
+			}
+		},
+		"@types/markdown-it-container": {
+			"version": "2.0.5",
+			"resolved": "http://bnpm.byted.org/@types/markdown-it-container/-/markdown-it-container-2.0.5.tgz",
+			"integrity": "sha512-8v5jIC5gcCUv+JcD0DExwNBkoKC0kLB4acensF0NoNlTIcXmQxF3RDjzAdIW82sXSoR+n772ePguxIWlq2ELvA==",
+			"dev": true,
+			"requires": {
+				"@types/markdown-it": "*"
+			}
+		},
+		"@types/mdurl": {
+			"version": "1.0.2",
+			"resolved": "http://bnpm.byted.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+			"dev": true
+		},
+		"markdown-it-container": {
+			"version": "3.0.0",
+			"resolved": "http://bnpm.byted.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+			"integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw=="
+		},
+		"regenerator-runtime": {
+			"version": "0.13.9",
+			"resolved": "http://bnpm.byted.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+		}
+	}
+}

--- a/plugins/lightblock/package.json
+++ b/plugins/lightblock/package.json
@@ -20,9 +20,11 @@
     "url": "https://github.com/yanmao-cc/am-editor/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.10"
+    "@babel/runtime": "^7.13.10",
+    "markdown-it-container": "^3.0.0"
   },
   "devDependencies": {
+    "@types/markdown-it-container": "^2.0.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"
   },

--- a/plugins/lightblock/src/component/markdown.ts
+++ b/plugins/lightblock/src/component/markdown.ts
@@ -1,0 +1,23 @@
+import container from 'markdown-it-container';
+import type MarkdownIt from 'markdown-it';
+import { encodeCardValue } from '@aomao/engine';
+
+export default function mk_lightblock(md: MarkdownIt) {
+	const defaultValue = {
+		borderColor: '#fed4a4',
+		backgroundColor: '#fff5eb',
+		text: 'light-block',
+	};
+
+	md.use(container, 'tip', {
+		render(tokens: any, idx: number) {
+			if (tokens[idx].nesting === 1) {
+				return `<div data-type="lightblock" data-value="${encodeCardValue(
+					defaultValue,
+				)}">`;
+			} else {
+				return '</div>';
+			}
+		},
+	});
+}

--- a/plugins/lightblock/src/index.ts
+++ b/plugins/lightblock/src/index.ts
@@ -12,8 +12,10 @@ import {
 	Parser,
 } from '@aomao/engine';
 import locales from './locale';
+import type MarkdownIt from 'markdown-it';
 import LightblockComponent from './component';
 import type { LightblockValue } from './component';
+import lightblockMk from './component/markdown';
 
 export interface LightblockOptions extends PluginOptions {}
 
@@ -28,6 +30,9 @@ export default class extends Plugin<LightblockOptions> {
 		editor.on('parse:html', this.parseHtml);
 		editor.on('paste:schema', this.pasteSchema);
 		editor.on('paste:each', this.pasteHtml);
+		if (isEngine(editor)) {
+			editor.on('markdown-it', this.markdownIt);
+		}
 	}
 
 	execute() {
@@ -42,6 +47,12 @@ export default class extends Plugin<LightblockOptions> {
 			text: 'light-block',
 		});
 	}
+
+	markdownIt = (markdown: MarkdownIt) => {
+		if (this.options.markdown !== false) {
+			lightblockMk(markdown);
+		}
+	};
 
 	pasteSchema = (schema: SchemaInterface) => {
 		schema.add({


### PR DESCRIPTION
### lightblock插件添加markdown快捷功能
```
::: tip  // 快捷示例
```
**改动范围**：lightblock插件、文档