### PR TITLE
fix: 修复聚焦的问题

### DIFF
--- a/plugins/lightblock/src/component/index.tsx
+++ b/plugins/lightblock/src/component/index.tsx
@@ -119,56 +119,69 @@ class Lightblock extends Card<LightblockValue> {
 
 	render() {
 		const value = this.getValue();
-		const { borderColor, backgroundColor } = value;
+		const { borderColor, backgroundColor, isFocus } = value;
 		const childValue = value.html
 			? new Parser(value.html, this.editor).toValue()
 			: '<br />';
 		this.#container = $(
-			`<div class="lightblock-container" style="border-color: ${borderColor};background-color:${backgroundColor};"><div class="lightblock-icon"><svg
-			viewBox="0 0 1024 1024"
-			version="1.1"
-			xmlns="http://www.w3.org/2000/svg"
-			p-id="13148"
-			width="24"
-			height="24"
-		>
-			<path
-				d="M833.5 330.5C833.5 153 689.6 7.6 512 7.6S190.5 153 190.5 330.5c0 70.3 37.3 161 97.2 227.9 59.4 66.3 103.5 177.9 103.5 266.9v34.9h241.6v-34.6c0-89 44.1-200.4 103.2-266.9 60.1-67.6 97.5-166.4 97.5-228.2z"
-				fill="#FFC807"
-				p-id="13149"
-			></path>
-			<path
-				d="M636.5 790.6l-193.9-268L596.4 202l199.2 266.4c-17.4 36.4-39.3 67.4-63.9 95.2C685.3 621 664.1 671.1 644 741l-7.5 49.6z"
-				fill="#FFB300"
-				p-id="13150"
-			></path>
-			<path
-				d="M499.5 378.3h-82.7c-12.6 0-21.4-12.7-16.8-24.5l59.2-153c2.7-6.9 9.4-11.5 16.8-11.5h105c13.6 0 22.3 14.5 15.9 26.5l-81.5 153c-3.2 5.8-9.3 9.5-15.9 9.5z"
-				fill="#FFF8E1"
-				p-id="13151"
-			></path>
-			<path
-				d="M466.2 518.3l160-171c12-12.8 2.9-33.7-14.6-33.7h-105c-8.7 0-16.4 5.6-19.1 13.9l-55 171c-6.6 20.4 19.1 35.5 33.7 19.8z"
-				fill="#FFF8E1"
-				p-id="13152"
-			></path>
-			<path
-				d="M593.6 1016.4H430.4c-5.7 0-10.9-3.7-14-9.8l-22.2-44.2h235.6l-22.2 44.2c-3.1 6.1-8.3 9.8-14 9.8z"
-				fill="#455A64"
-				p-id="13153"
-			></path>
-			<path
-				d="M625.7 980.4H398.3c-22.1 0-40.1-17.9-40.1-40.1V776.7c0-22.1 17.9-40.1 40.1-40.1h227.5c22.1 0 40.1 17.9 40.1 40.1v163.7c-0.1 22.1-18 40-40.2 40z"
-				fill="#ECEFF1"
-				p-id="13154"
-			></path>
-			<path
-				d="M539.8 808.6H359v-36h180.8c9.9 0 18 8.1 18 18 0 10-8.1 18-18 18zM359 840.1h306v36H359zM665 943.6H494.8c-9.9 0-18-8.1-18-18s8.1-18 18-18H665v36z"
-				fill="#CFD8DC"
-				p-id="13155"
-			></path>
-		</svg></div><div class="lightblock-editor-container">${childValue}</div></div>`,
+			`<div class="lightblock-container" style="border-color: ${borderColor};background-color:${backgroundColor};">
+				<div class="lightblock-icon">
+					<svg
+						viewBox="0 0 1024 1024"
+						version="1.1"
+						xmlns="http://www.w3.org/2000/svg"
+						p-id="13148"
+						width="24"
+						height="24"
+					>
+						<path
+							d="M833.5 330.5C833.5 153 689.6 7.6 512 7.6S190.5 153 190.5 330.5c0 70.3 37.3 161 97.2 227.9 59.4 66.3 103.5 177.9 103.5 266.9v34.9h241.6v-34.6c0-89 44.1-200.4 103.2-266.9 60.1-67.6 97.5-166.4 97.5-228.2z"
+							fill="#FFC807"
+							p-id="13149"
+						></path>
+						<path
+							d="M636.5 790.6l-193.9-268L596.4 202l199.2 266.4c-17.4 36.4-39.3 67.4-63.9 95.2C685.3 621 664.1 671.1 644 741l-7.5 49.6z"
+							fill="#FFB300"
+							p-id="13150"
+						></path>
+						<path
+							d="M499.5 378.3h-82.7c-12.6 0-21.4-12.7-16.8-24.5l59.2-153c2.7-6.9 9.4-11.5 16.8-11.5h105c13.6 0 22.3 14.5 15.9 26.5l-81.5 153c-3.2 5.8-9.3 9.5-15.9 9.5z"
+							fill="#FFF8E1"
+							p-id="13151"
+						></path>
+						<path
+							d="M466.2 518.3l160-171c12-12.8 2.9-33.7-14.6-33.7h-105c-8.7 0-16.4 5.6-19.1 13.9l-55 171c-6.6 20.4 19.1 35.5 33.7 19.8z"
+							fill="#FFF8E1"
+							p-id="13152"
+						></path>
+						<path
+							d="M593.6 1016.4H430.4c-5.7 0-10.9-3.7-14-9.8l-22.2-44.2h235.6l-22.2 44.2c-3.1 6.1-8.3 9.8-14 9.8z"
+							fill="#455A64"
+							p-id="13153"
+						></path>
+						<path
+							d="M625.7 980.4H398.3c-22.1 0-40.1-17.9-40.1-40.1V776.7c0-22.1 17.9-40.1 40.1-40.1h227.5c22.1 0 40.1 17.9 40.1 40.1v163.7c-0.1 22.1-18 40-40.2 40z"
+							fill="#ECEFF1"
+							p-id="13154"
+						></path>
+						<path
+							d="M539.8 808.6H359v-36h180.8c9.9 0 18 8.1 18 18 0 10-8.1 18-18 18zM359 840.1h306v36H359zM665 943.6H494.8c-9.9 0-18-8.1-18-18s8.1-18 18-18H665v36z"
+							fill="#CFD8DC"
+							p-id="13155"
+						></path>
+					</svg>
+				</div>
+				<div class="lightblock-editor-container">${childValue}</div>
+			</div>`,
 		);
+
+		if (isFocus) {
+			setTimeout(() => {
+				this.#container
+					.find('.lightblock-editor-container')?.[0]
+					.focus?.();
+			}, 0);
+		}
 
 		return this.#container;
 	}

--- a/plugins/lightblock/src/component/types.ts
+++ b/plugins/lightblock/src/component/types.ts
@@ -5,6 +5,7 @@ export interface LightblockValue extends CardValue {
 	backgroundColor: string;
 	text: string;
 	html?: string;
+	isFocus?: string;
 }
 
 export interface ILightblockProp {

--- a/plugins/lightblock/src/index.ts
+++ b/plugins/lightblock/src/index.ts
@@ -45,6 +45,7 @@ export default class extends Plugin<LightblockOptions> {
 			borderColor: '#fed4a4',
 			backgroundColor: '#fff5eb',
 			text: 'light-block',
+			isFocus: true,
 		});
 	}
 
@@ -107,10 +108,13 @@ export default class extends Plugin<LightblockOptions> {
 	};
 
 	renderHtml = (value: LightblockValue, cardName: string) => {
+		delete value.isFocus;
+
 		const htmlstring = new Parser(
 			value.html || value.text,
 			this.editor,
 		).toHTML();
+
 		return $(
 			`<div data-type="${cardName}" data-value="${encodeCardValue(
 				value,

--- a/plugins/mulit-codeblock/src/component/index.tsx
+++ b/plugins/mulit-codeblock/src/component/index.tsx
@@ -88,9 +88,9 @@ class MulitCode extends Card<MulitCodeblockValue> {
 		CM?.setOption('theme', theme);
 		this.setValue({ theme });
 
-		// setTimeout(() => {
-		//   CM?.focus();
-		// }, 16);
+		setTimeout(() => {
+			CM?.focus();
+		}, 16);
 	}
 
 	wrapChangeRefreshHtml() {

--- a/plugins/mulit-codeblock/src/component/type.ts
+++ b/plugins/mulit-codeblock/src/component/type.ts
@@ -11,6 +11,7 @@ export interface MulitCodeblockValue extends CardValue {
 	wrap: boolean;
 	theme: string;
 	height: string;
+	isFocus?: boolean;
 }
 
 export type FillMulitLang = Partial<MulitLangItem>;

--- a/plugins/mulit-codeblock/src/component/utils/hook.ts
+++ b/plugins/mulit-codeblock/src/component/utils/hook.ts
@@ -109,7 +109,8 @@ export function useMirrorEditor({
 		(mirror.current as unknown) = CM;
 
 		init(CM);
-		CM.focus();
+		// 创建时才聚焦
+		value.isFocus && CM.focus();
 		// codemirorr 监听事件
 		CM.on('focus', () => {
 			const { onFocus } = options;

--- a/plugins/mulit-codeblock/src/component/utils/render.ts
+++ b/plugins/mulit-codeblock/src/component/utils/render.ts
@@ -8,6 +8,7 @@ export default function renderHTMLTemplate(
 	props: MulitCodeblockValue,
 ) {
 	const { langs, height, theme } = props;
+	delete props.isFocus;
 
 	function renderHeader() {
 		let headerHtml = '';

--- a/plugins/mulit-codeblock/src/index.ts
+++ b/plugins/mulit-codeblock/src/index.ts
@@ -72,6 +72,7 @@ export default class extends Plugin<MulitCodeblockOptions> {
 			wrap: false,
 			theme: 'default',
 			height: 'auto',
+			isFocus: true,
 		});
 	}
 


### PR DESCRIPTION
### 修复 多功能代码块 和 高亮块 聚焦问题
**背景：**
* 在创建`高亮块`时，光标默认聚焦在right边界，用户需要自己点击高亮快才可以进行编辑。
* 在创建`多功能代码块`时，会自动聚焦（没有判断是创建还是渲染）在创建时是符合需求的，但是在渲染时会出现光标聚焦的竞态。