### PR TITLE
fix(bug): fix range error when  undo the history after deleting text …

### DIFF
--- a/packages/engine/src/history.ts
+++ b/packages/engine/src/history.ts
@@ -23,16 +23,12 @@ const setRangeByPath = (
 			startClone.pop();
 			endClone.pop();
 			const { container, change } = engine;
-			const startChild = start.id
-				? container.find(`[${DATA_ID}="${start.id}"]`).get<Node>()
-				: container.getChildByPath(
+			const startChild = container.getChildByPath(
 						startClone,
 						(child) => !isTransientElementCache($(child)),
 				  );
 			if (!startChild) return;
-			const endChild = end.id
-				? container.find(`[${DATA_ID}="${end.id}"]`).get<Node>()
-				: container.getChildByPath(
+			const endChild = container.getChildByPath(
 						endClone,
 						(child) => !isTransientElementCache($(child)),
 				  );


### PR DESCRIPTION
Two paragraphs，for example

222
333

1. Selected "22 33",such as 

2"22
33"3

2. click on backspace

3. press Ctrl+z to cancel

there is the problem that the selected text is not the previous 22 33, but 333